### PR TITLE
Gzipped output

### DIFF
--- a/lib/kingfisher.c
+++ b/lib/kingfisher.c
@@ -17,7 +17,7 @@
 		}\
 	} while(0)
 
-void kdmp_process_write(KingFisher_t *kfp, FILE *handle, tmpbuffers_t *bufs, int is_rev)
+void kdmp_process_write(KingFisher_t *kfp, gzFile handle, tmpbuffers_t *bufs, int is_rev)
 {
 	int i, diffs = kfp->length * kfp->readlen;
 	for(i = 0; i < kfp->readlen; ++i) {
@@ -33,7 +33,7 @@ void kdmp_process_write(KingFisher_t *kfp, FILE *handle, tmpbuffers_t *bufs, int
 			(double) diffs / kfp->length, bufs->cons_seq_buffer);
 	for(i = 0; i < kfp->readlen; ++i) kputc(kfp->max_phreds[nuc2num(bufs->cons_seq_buffer[i]) + 5 * i], &ks);
 	kputc('\n', &ks);
-	fputs(ks.s, handle);
+	gzputs(handle, ks.s);
 	free(ks.s);
 	return;
 }
@@ -91,7 +91,7 @@ void kstranded_process_write(KingFisher_t *kfpf, KingFisher_t *kfpr, FILE *handl
 		} else bufs->cons_quals[i] = 0, bufs->agrees[i] = 0, bufs->cons_seq_buffer[i] = 'N';
 	}
 	kstring_t ks = {0, 0, NULL};
-	ksprintf(&ks, "@ %s ", kfpf->barcode + 1);
+	ksprintf(&ks, "@%s ", kfpf->barcode + 1);
 	// Add read name
 	kfill_both(kfpf->readlen, bufs->agrees, bufs->cons_quals, &ks);
 	ksprintf(&ks, "\tFP:i:%c\tFM:i:%i\tRV:i:%i\tNF:f:%f\tDR:i:%i\n%s\n+\n", kfpf->pass_fail,
@@ -137,7 +137,7 @@ void zstranded_process_write(KingFisher_t *kfpf, KingFisher_t *kfpr, gzFile hand
 		} else bufs->cons_quals[i] = 0, bufs->agrees[i] = 0, bufs->cons_seq_buffer[i] = 'N';
 	}
 	kstring_t ks = {0, 0, NULL};
-	ksprintf(&ks, "@ %s ", kfpf->barcode + 1);
+	ksprintf(&ks, "@%s ", kfpf->barcode + 1);
 	// Add read name
 	kfill_both(kfpf->readlen, bufs->agrees, bufs->cons_quals, &ks);
 	ksprintf(&ks, "\tFP:i:%c\tFM:i:%i\tRV:i:%i\tNF:f:%f\tDR:i:%i\n%s\n+\n", kfpf->pass_fail,

--- a/lib/kingfisher.c
+++ b/lib/kingfisher.c
@@ -28,15 +28,59 @@ void kdmp_process_write(KingFisher_t *kfp, FILE *handle, tmpbuffers_t *bufs, int
 		const int index = argmaxret + i * 5;
 		dmp_pos(kfp, bufs, argmaxret, i, index, diffs);
 	}
-	kstring_t ks = {0, 0, NULL}, tmp = {0, 0, NULL};
-	kfill_agrees(kfp->readlen, bufs->agrees, &ks, &tmp);
-	kputc('\t', &ks);
-	kfill_pv(kfp->readlen, bufs->cons_quals, &ks, &tmp);
+	kstring_t ks = {0, 0, NULL};
+	ksprintf(&ks, "@%s ", kfp->barcode + 1);
+	kfill_both(kfp->readlen, bufs->agrees, bufs->cons_quals, &ks);
 	fprintf(handle, "@%s %s\tFP:i:%c\tFM:i:%i\tRV:i:%i\tNF:f:%0.6f\tDR:i:0\n%s\n+\n", kfp->barcode + 1,
 			ks.s, kfp->pass_fail, kfp->length, is_rev ? kfp->length: 0,
 			(double) diffs / kfp->length,
 			bufs->cons_seq_buffer);
+	free(ks.s);
 	for(i = 0; i < kfp->readlen; ++i) fputc(kfp->max_phreds[nuc2num(bufs->cons_seq_buffer[i]) + 5 * i], handle);
+	fputc('\n', handle);
+	return;
+}
+
+
+// kfp forward, kfp reverse
+// Note: You print kfpf->barcode + 1 because that skips the F/R/Z char.
+void kstranded_process_write(KingFisher_t *kfpf, KingFisher_t *kfpr, FILE *handle, tmpbuffers_t *bufs)
+{
+	const int FM = kfpf->length + kfpr->length;
+	int i, diffs = FM * kfpf->readlen;
+	int index;
+	kstring_t ks = {0, 0, NULL};
+
+	for(i = 0; i < kfpf->readlen; ++i) {
+		const int argmaxretf = kfp_argmax(kfpf, i), argmaxretr = kfp_argmax(kfpr, i);
+		if(argmaxretf == argmaxretr) { // Both strands supported the same base call.
+			index = i * 5 + argmaxretf;
+			kfpf->phred_sums[index] += kfpr->phred_sums[index];
+			kfpf->nuc_counts[index] += kfpr->nuc_counts[index];
+			dmp_pos(kfpf, bufs, argmaxretf, i, index, diffs);
+			if(kfpr->max_phreds[index] > kfpf->max_phreds[index]) kfpf->max_phreds[index] = kfpr->max_phreds[index];
+		} else if(argmaxretf == 4) { // Forward is Nd and reverse is not. Reverse call is probably right.
+			index = i * 5 + argmaxretr;
+			kfpf->phred_sums[index] += kfpr->phred_sums[index];
+			kfpf->nuc_counts[index] += kfpr->nuc_counts[index];
+			dmp_pos(kfpf, bufs, argmaxretr, i, index, diffs);
+			kfpf->max_phreds[index] = kfpr->max_phreds[index];
+		} else if(argmaxretr == 4) { // Forward is Nd and reverse is not. Reverse call is probably right.
+			index = i * 5 + argmaxretf;
+			kfpf->phred_sums[index] += kfpr->phred_sums[index];
+			kfpf->nuc_counts[index] += kfpr->nuc_counts[index];
+			dmp_pos(kfpf, bufs, argmaxretf, i, index, diffs);
+			// Don't update max_phreds, since the max phred is already here.
+		} else bufs->cons_quals[i] = 0, bufs->agrees[i] = 0, bufs->cons_seq_buffer[i] = 'N';
+	}
+	kfill_both(kfpf->readlen, bufs->agrees, bufs->cons_quals, &ks);
+	//const int ND = get_num_differ
+	fprintf(handle, "@%s %s\tFP:i:%c\tFM:i:%i\tRV:i:%i\tNF:f:%f\tDR:i:%i\n%s\n+\n", kfpf->barcode + 1,
+			ks.s, kfpf->pass_fail, FM, kfpr->length,
+			(double) diffs / FM, kfpf->length && kfpr->length,
+			bufs->cons_seq_buffer);
+	free(ks.s);
+	for(i = 0; i < kfpf->readlen; ++i) fputc(kfpf->max_phreds[nuc2num(bufs->cons_seq_buffer[i]) + 5 * i], handle);
 	fputc('\n', handle);
 	return;
 }

--- a/lib/kingfisher.c
+++ b/lib/kingfisher.c
@@ -20,6 +20,31 @@
 // TODO: rewrite dmp_process_write and stranded_process_write to write the PV/FA strings straight to output
 // rather than writing to a temporary object and writing that later.
 
+void kdmp_process_write(KingFisher_t *kfp, FILE *handle, tmpbuffers_t *bufs, int is_rev)
+{
+	int i, diffs = kfp->length * kfp->readlen;
+	for(i = 0; i < kfp->readlen; ++i) {
+		const int argmaxret = kfp_argmax(kfp, i);
+		const int index = argmaxret + i * 5;
+		dmp_pos(kfp, bufs, argmaxret, i, index, diffs);
+	}
+	kstring_t ks = {0, 0, NULL}, tmp = {0, 0, NULL};
+	kfill_agrees(kfp->readlen, bufs->agrees, &ks, &tmp);
+	kputc('\t', &ks);
+	kfill_pv(kfp->readlen, bufs->cons_quals, &ks, &tmp);
+	fprintf(handle, "@%s %s\tFP:i:%c\tFM:i:%i\tRV:i:%i\tNF:f:%0.6f\tDR:i:0\n%s\n+\n", kfp->barcode + 1,
+			ks.s, kfp->pass_fail, kfp->length, is_rev ? kfp->length: 0,
+			(double) diffs / kfp->length,
+			bufs->cons_seq_buffer);
+	for(i = 0; i < kfp->readlen; ++i) fputc(kfp->max_phreds[nuc2num(bufs->cons_seq_buffer[i]) + 5 * i], handle);
+	fputc('\n', handle);
+	return;
+}
+
+
+// TODO: rewrite dmp_process_write and stranded_process_write to write the PV/FA strings straight to output
+// rather than writing to a temporary object and writing that later.
+
 void dmp_process_write(KingFisher_t *kfp, FILE *handle, tmpbuffers_t *bufs, int is_rev)
 {
 	int i, diffs = kfp->length * kfp->readlen;

--- a/lib/kingfisher.h
+++ b/lib/kingfisher.h
@@ -72,7 +72,7 @@ static inline void pb_pos(KingFisher_t *kfp, kseq_t *seq, int i);
 static inline char rescale_qscore(int readnum, char qscore, int cycle, char base, int readlen, char *rescaler);
 void stranded_process_write(KingFisher_t *kfpf, KingFisher_t *kfpr, FILE *handle, tmpbuffers_t *bufs);
 void kstranded_process_write(KingFisher_t *kfpf, KingFisher_t *kfpr, FILE *handle, tmpbuffers_t *bufs);
-void dmp_process_write(KingFisher_t *kfp, FILE *handle, tmpbuffers_t *bufs, int is_rev);
+void dmp_process_write(KingFisher_t *kfp, gzFile handle, tmpbuffers_t *bufs, int is_rev);
 void kdmp_process_write(KingFisher_t *kfp, FILE *handle, tmpbuffers_t *bufs, int is_rev);
 CONST static inline int kfp_argmax(KingFisher_t *kfp, int index);
 CONST static inline int arr_max_u32(uint32_t *arr, int index);

--- a/lib/kingfisher.h
+++ b/lib/kingfisher.h
@@ -71,24 +71,31 @@ static inline void pushback_kseq(KingFisher_t *kfp, kseq_t *seq, int blen);
 static inline void pb_pos(KingFisher_t *kfp, kseq_t *seq, int i);
 static inline char rescale_qscore(int readnum, char qscore, int cycle, char base, int readlen, char *rescaler);
 void stranded_process_write(KingFisher_t *kfpf, KingFisher_t *kfpr, FILE *handle, tmpbuffers_t *bufs);
+void kstranded_process_write(KingFisher_t *kfpf, KingFisher_t *kfpr, FILE *handle, tmpbuffers_t *bufs);
 void dmp_process_write(KingFisher_t *kfp, FILE *handle, tmpbuffers_t *bufs, int is_rev);
 void kdmp_process_write(KingFisher_t *kfp, FILE *handle, tmpbuffers_t *bufs, int is_rev);
 CONST static inline int kfp_argmax(KingFisher_t *kfp, int index);
 CONST static inline int arr_max_u32(uint32_t *arr, int index);
 
-
-static inline void kfill_pv(int readlen, uint32_t *quals, kstring_t *ks, kstring_t *tmp)
+static inline void kfill_both(int readlen, uint16_t *agrees, uint32_t *quals, kstring_t *ks)
 {
-	kputsn("PV:B:I", 6, ks);
-	for(int i = 0; i < readlen; ++i)
-		kputc(',', ks), ksprintf(tmp, "%u", quals[i]), kputs(tmp->s, ks);
+	int i;
+	kputsn("FA:B:I", 6, ks);
+	for(i = 0; i < readlen; ++i) ksprintf(ks, ",%u", agrees[i]);
+	kputsn("\tPV:B:I", 7, ks);
+	for(i = 0; i < readlen; ++i) ksprintf(ks, ",%u", quals[i]);
 }
 
-static inline void kfill_agrees(int readlen, uint16_t *agrees, kstring_t *ks, kstring_t *tmp)
+static inline void kfill_pv(int readlen, uint32_t *quals, kstring_t *ks)
+{
+	kputsn("PV:B:I", 6, ks);
+	for(int i = 0; i < readlen; ++i) ksprintf(ks, ",%u", quals[i]);
+}
+
+static inline void kfill_agrees(int readlen, uint16_t *agrees, kstring_t *ks)
 {
 	kputsn("FA:B:I", 6, ks);
-	for(int i = 0; i < readlen; ++i)
-		kputc(',', ks), ksprintf(tmp, "%u", agrees[i]), kputs(tmp->s, ks);
+	for(int i = 0; i < readlen; ++i) ksprintf(ks, ",%u", agrees[i]);
 }
 
 /*

--- a/lib/kingfisher.h
+++ b/lib/kingfisher.h
@@ -71,9 +71,9 @@ static inline void pushback_kseq(KingFisher_t *kfp, kseq_t *seq, int blen);
 static inline void pb_pos(KingFisher_t *kfp, kseq_t *seq, int i);
 static inline char rescale_qscore(int readnum, char qscore, int cycle, char base, int readlen, char *rescaler);
 void stranded_process_write(KingFisher_t *kfpf, KingFisher_t *kfpr, FILE *handle, tmpbuffers_t *bufs);
-void kstranded_process_write(KingFisher_t *kfpf, KingFisher_t *kfpr, FILE *handle, tmpbuffers_t *bufs);
+void zstranded_process_write(KingFisher_t *kfpf, KingFisher_t *kfpr, gzFile handle, tmpbuffers_t *bufs);
 void dmp_process_write(KingFisher_t *kfp, gzFile handle, tmpbuffers_t *bufs, int is_rev);
-void kdmp_process_write(KingFisher_t *kfp, FILE *handle, tmpbuffers_t *bufs, int is_rev);
+void kdmp_process_write(KingFisher_t *kfp, gzFile handle, tmpbuffers_t *bufs, int is_rev);
 CONST static inline int kfp_argmax(KingFisher_t *kfp, int index);
 CONST static inline int arr_max_u32(uint32_t *arr, int index);
 

--- a/src/bmf_dmp.c
+++ b/src/bmf_dmp.c
@@ -83,7 +83,7 @@ void parallel_hash_dmp_core(marksplit_settings_t *settings, splitterhash_params_
 	for(int i = 0; i < settings->n_handles; ++i) {
 		fprintf(stderr, "[%s] Now running hash dmp core on input filename %s and output filename %s.\n",
 				__func__, params->infnames_r1[i], params->outfnames_r1[i]);
-		func(params->infnames_r1[i], params->outfnames_r1[i]);
+		func(params->infnames_r1[i], params->outfnames_r1[i], settings->gzip_compression);
 		if(settings->cleanup) {
 			char tmpbuf[500];
 			sprintf(tmpbuf, "rm %s", params->infnames_r1[i]);
@@ -95,12 +95,14 @@ void parallel_hash_dmp_core(marksplit_settings_t *settings, splitterhash_params_
 	for(int i = 0; i < settings->n_handles; ++i) {
 		fprintf(stderr, "[%s] Now running hash dmp core on input filename %s and output filename %s.\n",
 				__func__, params->infnames_r2[i], params->outfnames_r2[i]);
-		func(params->infnames_r2[i], params->outfnames_r2[i]);
+		func(params->infnames_r2[i], params->outfnames_r2[i], settings->gzip_compression);
+		kstring_t ks = {0, 0, NULL};
 		if(settings->cleanup) {
-			char tmpbuf[500];
-			sprintf(tmpbuf, "rm %s", params->infnames_r2[i]);
-			CHECK_CALL(tmpbuf);
+			ksprintf(&ks, "rm %s", params->infnames_r2[i]);
+			CHECK_CALL(ks.s);
+			ks.l = 0;
 		}
+		free(ks.s);
 	}
 }
 
@@ -108,71 +110,61 @@ void parallel_hash_dmp_core(marksplit_settings_t *settings, splitterhash_params_
 void call_clowder_se(marksplit_settings_t *settings, splitterhash_params_t *params, char *ffq_r1)
 {
 	// Clear output files.
-	char cat_buff[CAT_BUFFER_SIZE];
-	sprintf(cat_buff, settings->gzip_output ? "> %s.gz" : "> %s", ffq_r1);
-	CHECK_CALL(cat_buff);
+	kstring_t ks = {0, 0, NULL};
+	ksprintf(&ks, settings->gzip_output ? "> %s.gz" : "> %s", ffq_r1);
+	CHECK_CALL(ks.s);
 	for(int i = 0; i < settings->n_handles; ++i) {
+		ks.l = 0;
 		// Clear files if present
-		if(settings->gzip_output)
-			sprintf(cat_buff, "cat %s | pigz - -p %i -%i >> %s.gz",
-					params->outfnames_r1[i], settings->threads, settings->gzip_compression, ffq_r1);
-		else
-			sprintf(cat_buff, "cat %s >> %s", params->outfnames_r1[i], ffq_r1);
-		CHECK_POPEN(cat_buff);
+		ksprintf(&ks, "cat %s >> %s", params->outfnames_r1[i], ffq_r1);
+		CHECK_POPEN(ks.s);
 	}
+	free(ks.s);
 }
 
 void call_clowder_pe(marksplit_settings_t *settings, splitterhash_params_t *params, char *ffq_r1, char *ffq_r2)
 {
 	// Clear output files.
-	char cat_buff[CAT_BUFFER_SIZE];
-	sprintf(cat_buff, settings->gzip_output ? "> %s.gz" : "> %s", ffq_r1);
-	CHECK_CALL(cat_buff);
-	sprintf(cat_buff, settings->gzip_output ? "> %s.gz" : "> %s", ffq_r2);
-	CHECK_CALL(cat_buff);
+	kstring_t ks = {0, 0, NULL};
+	ksprintf(&ks, settings->gzip_output ? "> %s.gz" : "> %s", ffq_r1);
+	CHECK_CALL(ks.s);
+	ks.l = 0;
+	ksprintf(&ks, settings->gzip_output ? "> %s.gz" : "> %s", ffq_r2);
+	CHECK_CALL(ks.s);
 	for(int i = 0; i < settings->n_handles; ++i) {
 		// Clear files if present
-		if(settings->gzip_output)
-			sprintf(cat_buff, "cat %s | pigz - -p %i -%i >> %s.gz",
-					params->outfnames_r1[i], settings->threads >= 2 ? settings->threads >> 1: 1, settings->gzip_compression, ffq_r1);
-		else
-			sprintf(cat_buff, "cat %s >> %s", params->outfnames_r1[i], ffq_r1);
-		FILE *g1_popen = popen(cat_buff, "w");
-		if(settings->gzip_output)
-			sprintf(cat_buff, "cat %s | pigz - -p %i -%i >> %s.gz",
-					params->outfnames_r2[i], settings->threads >= 2 ? settings->threads >> 1: 1, settings->gzip_compression, ffq_r2);
-		else
-			sprintf(cat_buff, "cat %s >> %s", params->outfnames_r2[i], ffq_r2);
-		FILE *g2_popen = popen(cat_buff, "w");
+		ks.l = 0;
+		ksprintf(&ks, "cat %s >> %s", params->outfnames_r1[i], ffq_r1);
+		FILE *g1_popen = popen(ks.s, "w");
+		ks.l = 0;
+		ksprintf(&ks, "cat %s >> %s", params->outfnames_r2[i], ffq_r2);
+		FILE *g2_popen = popen(ks.s, "w");
 		if(pclose(g2_popen) || pclose(g1_popen)){
 			LOG_ERROR("Background system call failed.\n");
 		}
 	}
+	free(ks.s);
 }
 
 
 void call_panthera_se(marksplit_settings_t *settings, splitterhash_params_t *params, char *ffq_r1)
 {
-	char cat_buff[CAT_BUFFER_SIZE];
+	kstring_t ks = {0, 0, NULL};
 	// Clear output files.
-	sprintf(cat_buff, settings->gzip_output ? "> %s.gz" : "> %s", ffq_r1);
-	CHECK_CALL(cat_buff);
-	strcpy(cat_buff, "/bin/cat ");
+	ksprintf(&ks, settings->gzip_output ? "> %s.gz" : "> %s", ffq_r1);
+	CHECK_CALL(ks.s);
+	ks.l = 0;
+	ksprintf(&ks, "/bin/cat ");
 	for(int i = 0; i < settings->n_handles; ++i) {
 		if(!isfile(params->outfnames_r1[i])) {
 			LOG_ERROR("Output filename is not a file. Abort! ('%s').\n", params->outfnames_r1[i]);
 		}
-		strcat(cat_buff, params->outfnames_r1[i]); strcat(cat_buff, " ");
+		ksprintf(&ks, " %s", params->outfnames_r1[i]);
 	}
-	if(settings->gzip_output) {
-		char tmp_buf[CAT_BUFFER_SIZE];
-		sprintf(tmp_buf, " | pigz - -%i -p %i", settings->gzip_compression, settings->threads);
-		strcat(cat_buff, tmp_buf);
-	}
-	strcat(cat_buff, " > "); strcat(cat_buff, ffq_r1);
-	if(settings->gzip_output)
-		strcat(cat_buff, ".gz");
-	CHECK_POPEN(cat_buff);
+	ksprintf(&ks, " > %s", ffq_r1);
+	if(settings->gzip_output) kputs(".gz", &ks);
+	CHECK_POPEN(ks.s);
+	free(ks.s);
 }
 
 void check_rescaler(marksplit_settings_t *settings, int arr_size)
@@ -235,14 +227,17 @@ void call_panthera(marksplit_settings_t *settings, splitterhash_params_t *params
 
 void call_panthera_pe(marksplit_settings_t *settings, splitterhash_params_t *params, char *ffq_r1, char *ffq_r2)
 {
-	char cat_buff1[CAT_BUFFER_SIZE];
+	kstring_t ks1 = {0, 0, NULL};
+	kputs("> ", &ks1), kputs(ffq_r1, &ks1);
+	if(settings->gzip_output) kputs(".gz", &ks1);
 	// Clear output files.
-	sprintf(cat_buff1, settings->gzip_output ? "> %s.gz" : "> %s", ffq_r1);
-	CHECK_CALL(cat_buff1);
-	sprintf(cat_buff1, settings->gzip_output ? "> %s.gz" : "> %s", ffq_r2);
-	CHECK_CALL(cat_buff1);
-	strcpy(cat_buff1, "/bin/cat ");
-	char cat_buff2[CAT_BUFFER_SIZE] = "/bin/cat ";
+	//ksprintf(&ks1, settings->gzip_output ? "> %s.gz" : "> %s", ffq_r1);
+	CHECK_CALL(ks1.s); ks1.l = 0;
+	ksprintf(&ks1, settings->gzip_output ? "> %s.gz" : "> %s", ffq_r2);
+	CHECK_CALL(ks1.s); ks1.l = 0;
+	kputs("/bin/cat ", &ks1);
+	kstring_t ks2 = {0};
+	ksprintf(&ks2, ks1.s);
 	for(int i = 0; i < settings->n_handles; ++i) {
 		if(!isfile(params->outfnames_r1[i])) {
 			LOG_ERROR("Output filename is not a file. Abort! ('%s').\n", params->outfnames_r1[i]);
@@ -250,25 +245,19 @@ void call_panthera_pe(marksplit_settings_t *settings, splitterhash_params_t *par
 		if(!isfile(params->outfnames_r2[i])) {
 			LOG_ERROR("Output filename is not a file. Abort! ('%s').\n", params->outfnames_r2[i]);
 		}
-		strcat(cat_buff1, params->outfnames_r1[i]); strcat(cat_buff1, " ");
-		strcat(cat_buff2, params->outfnames_r2[i]); strcat(cat_buff2, " ");
+		ksprintf(&ks1, "%s ", params->outfnames_r1[i]);
+		ksprintf(&ks2, "%s ", params->outfnames_r2[i]);
 	}
-	if(settings->gzip_output) {
-		char tmp_buf[CAT_BUFFER_SIZE];
-		sprintf(tmp_buf, " | pigz - -%i -p %i", settings->gzip_compression, settings->threads >= 2 ? settings->threads >> 1: 1);
-		strcat(cat_buff1, tmp_buf); strcat(cat_buff2, tmp_buf);
-	}
-	strcat(cat_buff1, " > "); strcat(cat_buff1, ffq_r1);
-	strcat(cat_buff2, " > "); strcat(cat_buff2, ffq_r2);
+	ksprintf(&ks1, " > %s", ffq_r1);
+	ksprintf(&ks2, " > %s", ffq_r2);
 	if(settings->gzip_output)
-		strcat(cat_buff1, ".gz"), strcat(cat_buff2, ".gz");
-	LOG_DEBUG("About to call command '%s'.\n", cat_buff1);
-	LOG_DEBUG("About to call command '%s'.\n", cat_buff2);
-	FILE *c1_popen = popen(cat_buff1, "w");
-	FILE *c2_popen = popen(cat_buff2, "w");
+		kputs(".gz", &ks1), kputs(".gz", &ks2);
+	FILE *c1_popen = popen(ks1.s, "w");
+	FILE *c2_popen = popen(ks2.s, "w");
 	if(pclose(c2_popen) || pclose(c1_popen)) {
-		LOG_ERROR("Background cat command failed. ('%s' or '%s').\n", cat_buff1, cat_buff2);
+		LOG_ERROR("Background cat command failed. ('%s' or '%s').\n", ks1.s, ks2.s);
 	}
+	free(ks1.s), free(ks2.s);
 }
 
 void clean_homing_sequence(char *sequence) {
@@ -502,6 +491,8 @@ int dmp_main(int argc, char *argv[])
 			case 'h': print_crms_usage(argv[0]), exit(EXIT_SUCCESS);
 		}
 	}
+
+	if(!settings.gzip_output) settings.gzip_compression = 0;
 
 	// Check for proper command-line usage.
 	if(settings.is_se) {

--- a/src/bmf_dmp.c
+++ b/src/bmf_dmp.c
@@ -352,8 +352,8 @@ mark_splitter_t *pp_split_inline_se(marksplit_settings_t *settings)
 mark_splitter_t *pp_split_inline(marksplit_settings_t *settings)
 {
 #if WRITE_BARCODE_FQ
-	FILE *bcfp1 = fopen("tmp.molbc.r1.fq", "w");
-	FILE *bcfp2 = fopen("tmp.molbc.r2.fq", "w");
+	gzFile bcfp1 = gzopen("tmp.molbc.r1.fq.gz", "wb4");
+	gzFile bcfp2 = gzopen("tmp.molbc.r2.fq.gz", "wb4");
 #endif
 	LOG_INFO("Opening fastq files %s and %s.\n", settings->input_r1_path, settings->input_r2_path);
 	if(!(strcmp(settings->input_r1_path, settings->input_r2_path))) {
@@ -455,7 +455,7 @@ mark_splitter_t *pp_split_inline(marksplit_settings_t *settings)
 	kseq_destroy(seq1), kseq_destroy(seq2);
 	gzclose(fp1), gzclose(fp2);
 #ifdef WRITE_BARCODE_FQ
-	fclose(bcfp1), fclose(bcfp2);
+	gzclose(bcfp1), gzclose(bcfp2);
 #endif
 	return splitter;
 }

--- a/src/bmf_dmp.h
+++ b/src/bmf_dmp.h
@@ -142,7 +142,4 @@ static inline int nlen_homing_default(kseq_t *seq1, kseq_t *seq2, marksplit_sett
 		GZPUTS(seq2->qual.s, fp2); GZPUTC('\n', fp2);\
 	} while(0)
 
-#undef GZPUTC
-#undef GZPUTS
-
 #endif /* BMF_DMP_H */

--- a/src/bmf_dmp.h
+++ b/src/bmf_dmp.h
@@ -24,7 +24,7 @@
 
 extern int64_t ipow(int32_t, int32_t);
 
-typedef void (*hash_dmp_fn)(char *, char *);
+typedef void (*hash_dmp_fn)(char *, char *, int);
 
 #define CAT_BUFFER_SIZE 250000
 #define METASYNTACTIC_FNAME_BUFLEN 100

--- a/src/bmf_dmp.h
+++ b/src/bmf_dmp.h
@@ -117,26 +117,32 @@ static inline int nlen_homing_default(kseq_t *seq1, kseq_t *seq2, marksplit_sett
 	return default_len;
 }
 
+#define GZPUTC(char, handle) gzputc(handle, char)
+#define GZPUTS(char, handle) gzputs(handle, char)
+
 #define write_bc_to_file(fp1, fp2, seq1, seq2, settings)\
 	do {\
-		fputc('@', fp1), fputc('@', fp2);\
+		GZPUTC('@', fp1), GZPUTC('@', fp2);\
 		for(int k = 0; k < settings->blen1_2; ++k)\
-			fputc(seq1->seq.s[k + settings->offset], fp1),\
-			fputc(seq1->seq.s[k + settings->offset], fp2);\
+			GZPUTC(seq1->seq.s[k + settings->offset], fp1),\
+			GZPUTC(seq1->seq.s[k + settings->offset], fp2);\
 		for(int k = 0; k < settings->blen1_2; ++k)\
-			fputc(seq2->seq.s[k + settings->offset], fp1),\
-			fputc(seq2->seq.s[k + settings->offset], fp2);\
-		fputs(" ~#!#~|FP=1|BS=Z", fp1), fputs(" ~#!#~|FP=1|BS=Z", fp2);\
+			GZPUTC(seq2->seq.s[k + settings->offset], fp1),\
+			GZPUTC(seq2->seq.s[k + settings->offset], fp2);\
+		GZPUTS(" ~#!#~|FP=1|BS=Z", fp1), GZPUTS(" ~#!#~|FP=1|BS=Z", fp2);\
 		for(int k = 0; k < settings->blen1_2; ++k)\
-			fputc(seq1->seq.s[k + settings->offset], fp1),\
-			fputc(seq1->seq.s[k + settings->offset], fp2);\
+			GZPUTC(seq1->seq.s[k + settings->offset], fp1),\
+			GZPUTC(seq1->seq.s[k + settings->offset], fp2);\
 		for(int k = 0; k < settings->blen1_2; ++k)\
-			fputc(seq2->seq.s[k + settings->offset], fp1),\
-			fputc(seq2->seq.s[k + settings->offset], fp2);\
-		fputc('\n', fp1); fputs(seq1->seq.s, fp1); fputs("\n+\n", fp1);\
-		fputc('\n', fp2); fputs(seq2->seq.s, fp2); fputs("\n+\n", fp2);\
-		fputs(seq1->qual.s, fp1); fputc('\n', fp1);\
-		fputs(seq2->qual.s, fp2); fputc('\n', fp2);\
+			GZPUTC(seq2->seq.s[k + settings->offset], fp1),\
+			GZPUTC(seq2->seq.s[k + settings->offset], fp2);\
+		GZPUTC('\n', fp1); GZPUTS(seq1->seq.s, fp1); GZPUTS("\n+\n", fp1);\
+		GZPUTC('\n', fp2); GZPUTS(seq2->seq.s, fp2); GZPUTS("\n+\n", fp2);\
+		GZPUTS(seq1->qual.s, fp1); GZPUTC('\n', fp1);\
+		GZPUTS(seq2->qual.s, fp2); GZPUTC('\n', fp2);\
 	} while(0)
+
+#undef GZPUTC
+#undef GZPUTS
 
 #endif /* BMF_DMP_H */

--- a/src/bmf_err.cpp
+++ b/src/bmf_err.cpp
@@ -147,11 +147,6 @@ void err_fm_report(FILE *fp, fmerr_t *f)
 		if(kh_exist(f->hash2, k2))
 			if((k = kh_get(obs_union, key_union, kh_key(f->hash2, k2))) == kh_end(key_union))
 				k = kh_put(obs_union, key_union, kh_key(f->hash2, k2), &khr);
-#if !NDEBUG
-	for(k1 = kh_begin(f->hash1); k1 != kh_end(f->hash1); ++k1)
-		if(kh_exist(f->hash1, k1))
-			fprintf(stderr, "Key for FM: %i.\n",  kh_key(f->hash1, k1));
-#endif
 
 	// Write  header
 	fprintf(fp, "##PARAMETERS\n##refcontig:\"%s\"\n##bed:\"%s\"\n"
@@ -174,7 +169,6 @@ void err_fm_report(FILE *fp, fmerr_t *f)
 			fprintf(fp, "-nan\t");
 		else
 			fprintf(fp, "%0.12f\t", (double)kh_val(f->hash1, k1).err / kh_val(f->hash1, k1).obs);
-		LOG_DEBUG("R1 FM %i err, obs: %lu, %lu.\n", kh_key(f->hash1, k1), kh_val(f->hash1, k1).err, kh_val(f->hash1, k1).obs);
 
 		if((k2 = kh_get(obs, f->hash2, fm)) == kh_end(f->hash2))
 			fprintf(fp, "-nan\t");

--- a/src/bmf_hashdmp.c
+++ b/src/bmf_hashdmp.c
@@ -277,7 +277,8 @@ void stranded_hash_dmp_core(char *infname, char *outfname)
 		HASH_DEL(hrev, crev); HASH_DEL(hfor, cfor);
 		cond_free(crev); cond_free(cfor);
 	}
-	duplex_hash_process(hfor, cfor, tmp_hkf, crev, hrev, out_handle, tmp);
+	LOG_DEBUG("Before handling reverse only counts for non_duplex: %lu.\n", non_duplex);
+	//duplex_hash_process(hfor, cfor, tmp_hkf, crev, hrev, out_handle, tmp);
 	se_hash_process(hrev, crev, tmp_hkr, out_handle, tmp, &non_duplex);
 	LOG_DEBUG("Cleaning up.\n");
 	LOG_INFO("Number of duplex observations: %lu. Number of non-duplex observations: %lu\n", duplex, non_duplex);

--- a/src/bmf_hashdmp.h
+++ b/src/bmf_hashdmp.h
@@ -13,15 +13,14 @@ extern "C" {
 #endif
 
 KHASH_MAP_INIT_STR(dmp, KingFisher_t *)
-void hash_dmp_core(char *infname, char *outfname);
+void hash_dmp_core(char *infname, char *outfname, int level);
 int hash_dmp_main(int argc, char *argv[]);
 #ifdef __cplusplus
 extern "C" {
 #endif
 	extern void splitterhash_destroy(splitterhash_params_t *params);
-	extern void kdmp_process_write(KingFisher_t *kfp, FILE *handle, tmpbuffers_t *bufs, int is_rev);
 	extern splitterhash_params_t *init_splitterhash(marksplit_settings_t *settings_ptr, mark_splitter_t *splitter_ptr);
-	void stranded_hash_dmp_core(char *infname, char *outfname);
+	void stranded_hash_dmp_core(char *infname, char *outfname, int level);
 	tmpvars_t *init_tmpvars_p(char *bs_ptr, int blen, int readlen);
 #ifdef __cplusplus
 }
@@ -39,8 +38,8 @@ CONST static inline int infer_barcode_length(char *bs_ptr)
 	char *const current = bs_ptr;
 	for (;;) {
 		switch(*bs_ptr++) {
-		case '|': // Fall-through
-		case '\0': return bs_ptr - current - 1;
+		case '|': case '\0':
+			return bs_ptr - current - 1;
 		}
 	}
 	return -1; // This never happens.

--- a/src/bmf_hashdmp.h
+++ b/src/bmf_hashdmp.h
@@ -19,6 +19,7 @@ int hash_dmp_main(int argc, char *argv[]);
 extern "C" {
 #endif
 	extern void splitterhash_destroy(splitterhash_params_t *params);
+	extern void kdmp_process_write(KingFisher_t *kfp, FILE *handle, tmpbuffers_t *bufs, int is_rev);
 	extern splitterhash_params_t *init_splitterhash(marksplit_settings_t *settings_ptr, mark_splitter_t *splitter_ptr);
 	void stranded_hash_dmp_core(char *infname, char *outfname);
 	tmpvars_t *init_tmpvars_p(char *bs_ptr, int blen, int readlen);


### PR DESCRIPTION
BMFtools now defaults to writing uncompressed plain text output, but if the -z or -g flags are provided, it will write out compressed final output files.

All unit tests passing.