### PR TITLE
Fix issue 98

### DIFF
--- a/include/kseq.h
+++ b/include/kseq.h
@@ -127,7 +127,7 @@ typedef struct __kstring_t {
             } \
             seek_pos += i - ks->begin; if ( i < ks->end ) seek_pos++; \
             gotany = 1; \
-            memcpy(str->s + str->l, ks->buf + ks->begin, i - ks->begin);  \
+            std::memcpy(str->s + str->l, ks->buf + ks->begin, i - ks->begin);  \
             str->l = str->l + (i - ks->begin); \
             ks->begin = i + 1; \
             if (i < ks->end) { \

--- a/include/kstring.h
+++ b/include/kstring.h
@@ -140,7 +140,7 @@ static inline int kputsn(const char *p, int l, kstring_t *s)
         else
             return EOF;
     }
-    memcpy(s->s + s->l, p, l);
+    std::memcpy(s->s + s->l, p, l);
     s->l += l;
     s->s[s->l] = 0;
     return l;
@@ -193,7 +193,7 @@ static inline int kputsn_(const void *p, int l, kstring_t *s)
         else
             return EOF;
     }
-    memcpy(s->s + s->l, p, l);
+    std::memcpy(s->s + s->l, p, l);
     s->l += l;
     return l;
 }

--- a/lib/hashdmp.cpp
+++ b/lib/hashdmp.cpp
@@ -1,5 +1,6 @@
 #include <cassert>
 #include <cinttypes>
+#include <cstring>
 #include "src/bmf_collapse.h"
 #include "dlib/io_util.h"
 #include "lib/mseq.h"
@@ -217,7 +218,7 @@ sprintf(mode, level > 0 ? "wb%i": "wT", level % 10);
         blen1 = get_blen(seq1->seq.s, homing, homing_len, blen, max_blen, mask);
         blen2 = get_blen(seq2->seq.s, homing, homing_len, blen, max_blen, mask);
         if(switch_test(seq1, seq2, mask)) {
-            if(blen2 != (unsigned)-1) memcpy(barcode.s, seq2->seq.s + mask, blen2);
+            if(blen2 != (unsigned)-1) std::memcpy(barcode.s, seq2->seq.s + mask, blen2);
             else {
                 pass = 0;
                 blen2 = blen - mask;
@@ -230,7 +231,7 @@ sprintf(mode, level > 0 ? "wb%i": "wT", level % 10);
                     kroundup32(barcode.m);
                     barcode.s = (char *)realloc(barcode.s, barcode.m);
                 }
-                memcpy(barcode.s + barcode.l, seq1->seq.s + mask, blen2);
+                std::memcpy(barcode.s + barcode.l, seq1->seq.s + mask, blen2);
             } else {
                 pass = 0;
                 blen1 = blen - mask;
@@ -255,14 +256,14 @@ sprintf(mode, level > 0 ? "wb%i": "wT", level % 10);
                 tmp_hk2 = (kingfisher_hash_t *)malloc(sizeof(kingfisher_hash_t));
                 tmp_hk1->value = init_kfp(seq2->seq.l - offset2);
                 tmp_hk2->value = init_kfp(seq1->seq.l - offset1);
-                memcpy(tmp_hk1->id, barcode.s, barcode.l);
-                memcpy(tmp_hk2->id, barcode.s, barcode.l);
+                std::memcpy(tmp_hk1->id, barcode.s, barcode.l);
+                std::memcpy(tmp_hk2->id, barcode.s, barcode.l);
                 tmp_hk1->id[barcode.l] = '\0';
                 tmp_hk2->id[barcode.l] = '\0';
-                memcpy(tmp_hk1->value->barcode + 1, barcode.s, barcode.l);
+                std::memcpy(tmp_hk1->value->barcode + 1, barcode.s, barcode.l);
                 tmp_hk1->value->barcode[0] = '@';
                 tmp_hk1->value->barcode[barcode.l + 1] = '\0';
-                memcpy(tmp_hk2->value->barcode + 1, barcode.s, barcode.l);
+                std::memcpy(tmp_hk2->value->barcode + 1, barcode.s, barcode.l);
                 tmp_hk2->value->barcode[0] = '@';
                 tmp_hk2->value->barcode[barcode.l + 1] = '\0';
                 pushback_inmem(tmp_hk2->value, seq1, offset1, pass);
@@ -271,7 +272,7 @@ sprintf(mode, level > 0 ? "wb%i": "wT", level % 10);
                 HASH_ADD_STR(hash2r, id, tmp_hk2);
             }
         } else {
-            if(blen1 != (unsigned)-1) memcpy(barcode.s, seq1->seq.s + mask, blen1);
+            if(blen1 != (unsigned)-1) std::memcpy(barcode.s, seq1->seq.s + mask, blen1);
             else { // Fail!
                 pass = 0;
                 blen1 = blen - mask;
@@ -284,7 +285,7 @@ sprintf(mode, level > 0 ? "wb%i": "wT", level % 10);
                     kroundup32(barcode.m);
                     barcode.s = (char *)realloc(barcode.s, barcode.m);
                 }
-                memcpy(barcode.s + barcode.l, seq2->seq.s + mask, blen2);
+                std::memcpy(barcode.s + barcode.l, seq2->seq.s + mask, blen2);
             } else {
                 pass = 0;
                 blen2 = blen - mask;
@@ -308,14 +309,14 @@ sprintf(mode, level > 0 ? "wb%i": "wT", level % 10);
                 tmp_hk2 = (kingfisher_hash_t *)malloc(sizeof(kingfisher_hash_t));
                 tmp_hk1->value = init_kfp(seq1->seq.l - offset1);
                 tmp_hk2->value = init_kfp(seq2->seq.l - offset2);
-                memcpy(tmp_hk1->id, barcode.s, barcode.l);
-                memcpy(tmp_hk2->id, barcode.s, barcode.l);
+                std::memcpy(tmp_hk1->id, barcode.s, barcode.l);
+                std::memcpy(tmp_hk2->id, barcode.s, barcode.l);
                 tmp_hk1->id[barcode.l] = '\0';
                 tmp_hk2->id[barcode.l] = '\0';
-                memcpy(tmp_hk1->value->barcode + 1, barcode.s, barcode.l);
+                std::memcpy(tmp_hk1->value->barcode + 1, barcode.s, barcode.l);
                 tmp_hk1->value->barcode[barcode.l + 1] = '\0';
                 tmp_hk1->value->barcode[0] = '@';
-                memcpy(tmp_hk2->value->barcode + 1, barcode.s, barcode.l);
+                std::memcpy(tmp_hk2->value->barcode + 1, barcode.s, barcode.l);
                 tmp_hk2->value->barcode[barcode.l + 1] = '\0';
                 tmp_hk2->value->barcode[0] = '@';
                 HASH_ADD_STR(hash1f, id, tmp_hk1);
@@ -419,7 +420,7 @@ void hash_dmp_core(char *infname, char *outfname, int level)
     const int blen(infer_barcode_length(bs_ptr));
     LOG_DEBUG("Barcode length (inferred): %i.\n", blen);
     tmpvars_t *tmp(init_tmpvars_p(bs_ptr, blen, seq->seq.l));
-    memcpy(tmp->key, bs_ptr, blen);
+    std::memcpy(tmp->key, bs_ptr, blen);
     tmp->key[blen] = '\0';
     // Start hash table
     kingfisher_hash_t *hash(nullptr);
@@ -502,7 +503,7 @@ void stranded_hash_dmp_core(char *infname, char *outfname, int level)
     int blen = infer_barcode_length(bs_ptr);
     LOG_DEBUG("Barcode length (inferred): %i. First barcode: %s.\n", blen, bs_ptr);
     tmpvars_t *tmp = init_tmpvars_p(bs_ptr, blen, seq->seq.l);
-    memcpy(tmp->key, bs_ptr, blen);
+    std::memcpy(tmp->key, bs_ptr, blen);
     tmp->key[blen] = '\0';
     // Start hash table
     kingfisher_hash_t *hfor(nullptr), *hrev(nullptr); // Hash forward, hash reverse

--- a/lib/hashdmp.cpp
+++ b/lib/hashdmp.cpp
@@ -86,7 +86,7 @@ int hashcollapse_main(int argc, char *argv[])
     else LOG_WARNING("Note: no input filename provided. Defaulting to stdin.\n");
     stranded_analysis ? stranded_hash_dmp_core(infname, outfname, level)
                       : hash_dmp_core(infname, outfname, level);
-    LOG_INFO("Successfully complete bmftools hashdmp!\n");
+    LOG_INFO("Successfully completed bmftools hashdmp!\n");
     return EXIT_SUCCESS;
 }
 
@@ -133,7 +133,7 @@ int hashdmp_inmem_main(int argc, char *argv[])
     hash_inmem_inline_core(argv[optind], argv[optind + 1], outfname1, outfname2,
                            homing, blen, threshold, level, mask,
                            max_blen);
-    LOG_INFO("Successfully complete bmftools hashdmp!\n");
+    LOG_INFO("Successfully completed bmftools hashdmp!\n");
     return EXIT_SUCCESS;
 }
 

--- a/lib/kingfisher.cpp
+++ b/lib/kingfisher.cpp
@@ -14,7 +14,6 @@ namespace bmf {
         if(bufs->cons_quals[i] > 2 && (double)bufs->agrees[i] / kfp->length > MIN_FRAC_AGREED)\
             bufs->cons_seq_buffer[i] = num2nuc(argmaxret);\
         else bufs->cons_quals[i] = 2, bufs->cons_seq_buffer[i] = 'N';\
-        }\
     } while(0)
 
 void dmp_process_write(kingfisher_t *kfp, kstring_t *ks, tmpbuffers_t *bufs, int is_rev)

--- a/lib/kingfisher.cpp
+++ b/lib/kingfisher.cpp
@@ -70,20 +70,6 @@ std::vector<std::vector<double>> get_igamc_thresholds(size_t max_family_size, in
     return ret;
 }
 
-int kf_hamming(kingfisher_t *kf1, kingfisher_t *kf2) {
-    int ret(0);
-    int argmaxret1, argmaxret2;
-    for(int i(0); i < kf1->readlen; ++i) {
-        argmaxret1 = kfp_argmax(kf1, i);
-        argmaxret2 = kfp_argmax(kf2, i);
-        if(argmaxret1 != argmaxret2)
-            if(argmaxret1 != 4)
-                if(argmaxret2 != 4)
-                    ++ret;
-    }
-    return ret;
-}
-
 // kfp forward, kfp reverse
 // Note: You print kfpf->barcode + 1 because that skips the F/R/Z char.
 void zstranded_process_write(kingfisher_t *kfpf, kingfisher_t *kfpr, kstring_t *ks, tmpbuffers_t *bufs)

--- a/lib/kingfisher.cpp
+++ b/lib/kingfisher.cpp
@@ -11,11 +11,9 @@ namespace bmf {
         bufs->agrees[i] = kfp->nuc_counts[index];\
         diffcount -= bufs->agrees[i];\
         if(argmaxret != 4) diffcount -= kfp->nuc_counts[i * 5 + 4]; /*(Skip Ns in counting diffs) */\
-        if(bufs->cons_quals[i] > 2 && (double)bufs->agrees[i] / kfp->length > MIN_FRAC_AGREED) {\
+        if(bufs->cons_quals[i] > 2 && (double)bufs->agrees[i] / kfp->length > MIN_FRAC_AGREED)\
             bufs->cons_seq_buffer[i] = num2nuc(argmaxret);\
-        } else {\
-            bufs->cons_quals[i] = 2;\
-            bufs->cons_seq_buffer[i] = 'N';\
+        else bufs->cons_quals[i] = 2, bufs->cons_seq_buffer[i] = 'N';\
         }\
     } while(0)
 
@@ -27,7 +25,7 @@ void dmp_process_write(kingfisher_t *kfp, kstring_t *ks, tmpbuffers_t *bufs, int
         const int index(argmaxret + i * 5);
         dmp_pos(kfp, bufs, argmaxret, i, index, diffs);
     }
-    ksprintf(ks, "@%s ", kfp->barcode + 1);
+    kputc('@', ks); kputs(kfp->barcode + 1, ks); kputc(' ', ks); 
     kfill_both(kfp->readlen, bufs->agrees, bufs->cons_quals, ks);
     bufs->cons_seq_buffer[kfp->readlen] = '\0';
     kputsnl("\tFP:i:", ks);

--- a/lib/kingfisher.h
+++ b/lib/kingfisher.h
@@ -62,7 +62,15 @@ struct kingfisher_t {
 
 void zstranded_process_write(kingfisher_t *kfpf, kingfisher_t *kfpr, kstring_t *ks, tmpbuffers_t *bufs);
 void dmp_process_write(kingfisher_t *kfp, kstring_t *ks, tmpbuffers_t *bufs, int is_rev);
-int kf_hamming(kingfisher_t *kf1, kingfisher_t *kf2);
+CONST static inline int kfp_argmax(kingfisher_t *kfp, int index);
+static inline int kf_hamming(kingfisher_t *kf1, kingfisher_t *kf2) {
+    int ret(0);
+    for(int i(0), argmaxret1, argmaxret2; i < kf1->readlen; ++i)
+        if((argmaxret1 = kfp_argmax(kf1, i)) != (argmaxret2 = kfp_argmax(kf2, i)))
+            ret += (argmaxret1 != 4) && (argmaxret2 != 4);
+    return ret;
+}
+
 
 static inline void kfill_both(int readlen, uint16_t *agrees, uint32_t *quals, kstring_t *ks)
 {

--- a/lib/kingfisher.h
+++ b/lib/kingfisher.h
@@ -2,6 +2,7 @@
 #define KINGFISHER_H
 #include <assert.h>
 #include <cmath>
+#include <cstring>
 #include <zlib.h>
 #include "htslib/khash.h"
 #include "htslib/kseq.h"
@@ -103,7 +104,7 @@ static inline void pushback_kseq(kingfisher_t *kfp, kseq_t *seq, int blen)
 {
     if(!kfp->length++) { // Increment while checking
         kfp->pass_fail = seq->comment.s[FP_OFFSET];
-        memcpy(kfp->barcode, seq->comment.s + HASH_DMP_OFFSET, blen);
+        std::memcpy(kfp->barcode, seq->comment.s + HASH_DMP_OFFSET, blen);
         kfp->barcode[blen] = '\0';
     }
     for(int i(0); i < kfp->readlen; ++i) pb_pos(kfp, seq, i);

--- a/lib/mseq.cpp
+++ b/lib/mseq.cpp
@@ -29,10 +29,10 @@ mseq_t *mseq_init(kseq_t *seq, char *rescaler, int is_read2)
         exit(EXIT_FAILURE);
     }
     mseq_t *ret((mseq_t *)calloc(1, sizeof(mseq_t)));
-    strcpy(ret->name, seq->name.s);
-    strcpy(ret->comment, seq->comment.s ? seq->comment.s: "");
-    strcpy(ret->seq, seq->seq.s);
-    strcpy(ret->qual, seq->qual.s);
+    std::strcpy(ret->name, seq->name.s);
+    std::strcpy(ret->comment, seq->comment.s ? seq->comment.s: "");
+    std::strcpy(ret->seq, seq->seq.s);
+    std::strcpy(ret->qual, seq->qual.s);
 
     ret->l = seq->seq.l;
     if(rescaler)

--- a/lib/mseq.cpp
+++ b/lib/mseq.cpp
@@ -30,7 +30,7 @@ mseq_t *mseq_init(kseq_t *seq, char *rescaler, int is_read2)
     }
     mseq_t *ret((mseq_t *)calloc(1, sizeof(mseq_t)));
     strcpy(ret->name, seq->name.s);
-    strcpy(ret->comment, seq->comment.s);
+    strcpy(ret->comment, seq->comment.s ? seq->comment.s: "");
     strcpy(ret->seq, seq->seq.s);
     strcpy(ret->qual, seq->qual.s);
 

--- a/lib/mseq.h
+++ b/lib/mseq.h
@@ -46,11 +46,10 @@ CONST static inline char *mem_view(char *comment)
 {
     int hits(0);
     loop_start:
-    switch(*comment++) {
+    switch(*comment++)
         case '|': case '\0':
-            if(hits) return (char *)comment + 3;
-            else ++hits; // + 3 for |BS= minus 1, since we already incremented for the switch.
-    }
+            if(hits) return (char *)comment + 3;else ++hits;
+            // + 3 for |BS= minus 1, since we already incremented for the switch.
     goto loop_start;
 }
 

--- a/lib/mseq.h
+++ b/lib/mseq.h
@@ -2,6 +2,7 @@
 #define MSEQ_H
 #include <zlib.h>
 #include <cstdint>
+#include <cstring>
 #include "htslib/kseq.h"
 #include "dlib/compiler_util.h"
 #include "dlib/cstr_util.h"
@@ -77,14 +78,14 @@ CONST static inline int switch_test(kseq_t *seq1, kseq_t *seq2, int offset)
 static inline int set_barcode(kseq_t *seq1, kseq_t *seq2, char *barcode, uint32_t offset, uint32_t blen1_2)
 {
     if(switch_test(seq1, seq2, offset)) { // seq1's barcode is lower. No switching.
-        memcpy(barcode, seq1->seq.s + offset, blen1_2 * sizeof(char)); // Copying the first half of the barcode
-        memcpy(barcode + blen1_2, seq2->seq.s + offset,
+        std::memcpy(barcode, seq1->seq.s + offset, blen1_2 * sizeof(char)); // Copying the first half of the barcode
+        std::memcpy(barcode + blen1_2, seq2->seq.s + offset,
                blen1_2 * sizeof(char));
         barcode[blen1_2 * 2] = '\0';
         return 0;
     } else {
-        memcpy(barcode, seq2->seq.s + offset, blen1_2 * sizeof(char)); // Copying the first half of the barcode
-        memcpy(barcode + blen1_2, seq1->seq.s + offset,
+        std::memcpy(barcode, seq2->seq.s + offset, blen1_2 * sizeof(char)); // Copying the first half of the barcode
+        std::memcpy(barcode + blen1_2, seq1->seq.s + offset,
                blen1_2 * sizeof(char));
         barcode[blen1_2 * 2] = '\0';
         return 1;
@@ -147,16 +148,16 @@ static inline void mseq2fq(gzFile handle, mseq_t *mvar, int pass_fail, char *bar
  */
 static inline void update_mseq(mseq_t *mvar, kseq_t *seq, char *rescaler, tmp_mseq_t *tmp, int n_len, int is_read2)
 {
-    memcpy(mvar->name, seq->name.s, seq->name.l);
+    std::memcpy(mvar->name, seq->name.s, seq->name.l);
     mvar->name[seq->name.l] = '\0';
-    memcpy(mvar->seq, seq->seq.s + n_len, seq->seq.l - n_len);
+    std::memcpy(mvar->seq, seq->seq.s + n_len, seq->seq.l - n_len);
     mvar->seq[seq->seq.l - n_len] = '\0';
     mvar->qual[seq->qual.l - n_len] = '\0';
     if(rescaler)
         for(unsigned i(n_len); i < seq->seq.l; ++i)
             mvar->qual[i - n_len] = rescale_qscore(is_read2, seq->qual.s[i], i,
                                                    seq->seq.s[i], seq->seq.l, rescaler);
-    else memcpy(mvar->qual, seq->qual.s + n_len, seq->qual.l - n_len);
+    else std::memcpy(mvar->qual, seq->qual.s + n_len, seq->qual.l - n_len);
 }
 
 // TMP_MSEQ Utilities

--- a/lib/splitter.cpp
+++ b/lib/splitter.cpp
@@ -11,16 +11,6 @@ namespace bmf {
 
 void splitterhash_destroy(splitterhash_params_t *params)
 {
-    /*
-     * Is this freed by splitterhash_params?
-    for(int i = 0; i < params->n; ++i) {
-        LOG_DEBUG("i: %i.\n", i);
-        cond_free(params->outfnames_r1[i]);
-        cond_free(params->outfnames_r2[i]);
-        cond_free(params->infnames_r1[i]);
-        cond_free(params->infnames_r2[i]);
-    }
-    */
     cond_free(params->outfnames_r1);
     cond_free(params->outfnames_r2);
     cond_free(params->infnames_r1);

--- a/src/bmf_collapse.cpp
+++ b/src/bmf_collapse.cpp
@@ -55,13 +55,14 @@ void idmp_usage()
 }
 
 kstring_t salted_rand_string(char *infname, size_t n_rand) {
-    if(strchr(infname, '/')) infname = strrchr(infname, '/') + 1;
+    if(std::strchr(infname, '/')) infname = strrchr(infname, '/') + 1;
     std::string tmp(infname);
-    while(strchr(tmp.c_str(), '.')) {
-        int n(tmp.c_str() + tmp.size() - strchr(tmp.c_str(), '.') + 1);
-        while(n--) tmp.pop_back();
+    while(std::strchr(tmp.c_str(), '.')) {
+        int n(tmp.c_str() + tmp.size() - std::strchr(tmp.c_str(), '.') + 1);
+        while(--n) tmp.pop_back();
     }
-    size_t flen(tmp.size() + n_rand);
+    tmp.push_back('.');
+    size_t flen(tmp.size() + n_rand + 1);
     const char cstr[] {"ABCDEFGHIJKLMNOPQRTSUVWXYZ1234567890"};
     while(tmp.size() < flen) tmp.push_back(cstr[rand() % (sizeof(cstr) - 1)]);
     kstring_t ret{0};
@@ -73,7 +74,7 @@ kstring_t salted_rand_string(char *infname, size_t n_rand) {
  */
 char *make_salted_fname(char *base)
 {
-    if(strchr(base, '\0')) {
+    if(std::strchr(base, '.')) {
         kstring_t rs(salted_rand_string(base, RANDSTR_SIZE));
         LOG_INFO("No output final prefix set. Defaulting to variation on input ('%s').\n", base);
         return rs.s;

--- a/src/bmf_collapse.cpp
+++ b/src/bmf_collapse.cpp
@@ -73,13 +73,7 @@ kstring_t salted_rand_string(char *infname, size_t n_rand) {
  */
 char *make_salted_fname(char *base)
 {
-    int has_period(0);
-    for(int i(0); base[i]; ++i) {
-        if(base[i] == '.') {
-            has_period = 1; break;
-        }
-    }
-    if(has_period) {
+    if(strchr(base, '\0')) {
         kstring_t rs(salted_rand_string(base, RANDSTR_SIZE));
         LOG_INFO("No output final prefix set. Defaulting to variation on input ('%s').\n", base);
         return rs.s;
@@ -316,8 +310,7 @@ mark_splitter_t pp_split_inline_se(marksplit_settings_t *settings)
     }
     LOG_INFO("Collapsing %lu initial reads....\n", count);
     LOG_DEBUG("Cleaning up.\n");
-    for(int i(0); i < splitter.n_handles; ++i)
-        gzclose(splitter.tmp_out_handles_r1[i]);
+    for(int i(0); i < splitter.n_handles; ++i) gzclose(splitter.tmp_out_handles_r1[i]);
     tm_destroy(tmp);
     mseq_destroy(rseq);
     kseq_destroy(seq);

--- a/src/bmf_collapse.cpp
+++ b/src/bmf_collapse.cpp
@@ -611,7 +611,7 @@ void sdmp_usage(char *argv[])
                         "-n: Number of nucleotides at the beginning of the barcode to use to split the output. Default: %i.\n"
                         "-z: Flag to write gzip compressed output. Default: False.\n"
                         "-T: If unset, write uncompressed plain text temporary files. If not, use that compression level for temporary files.\n"
-                        "-g: Gzip compression ratio if writing ocmpressed. Default (if writing compressed): 1 (mostly to reduce I/O).\n"
+                        "-g: Gzip compression ratio if writing compressed. Default: 1 (mostly to reduce I/O).\n"
                         "-s: Number of bases from reads 1 and 2 with which to salt the barcode. Default: 0.\n"
                         "-m: Number of bases in the start of reads to skip when salting. Default: 0.\n"
                         "-D: Use this flag to only mark/split and avoid final demultiplexing/consolidation.\n"
@@ -629,10 +629,10 @@ static mark_splitter_t splitmark_core_rescale(marksplit_settings_t *settings)
 {
     LOG_DEBUG("Path to index fq: %s.\n", settings->index_fq_path);
     gzFile fp_read1, fp_read2, fp_index;
-    kseq_t *seq1(nullptr), *seq2(nullptr), *seq_index(nullptr);
+    kseq_t *seq1, *seq2, *seq_index;
     int l1, l2, l_index;
     mark_splitter_t splitter(init_splitter(settings));
-    for(auto path: {settings->input_r1_path, settings->input_r2_path, settings->index_fq_path})
+    for(const auto path: {settings->input_r1_path, settings->input_r2_path, settings->index_fq_path})
         if(!dlib::isfile(path))
             LOG_EXIT("%s is not a file. Abort!\n", path);
     // Open fastqs

--- a/src/bmf_collapse.cpp
+++ b/src/bmf_collapse.cpp
@@ -284,7 +284,7 @@ mark_splitter_t pp_split_inline_se(marksplit_settings_t *settings)
     int n_len(nlen_homing_se(seq, settings, default_nlen, &pass_fail));
     mseq_t *rseq(mseq_rescale_init(seq, settings->rescaler, tmp, 0));
     rseq->barcode[settings->blen] = '\0';
-    memcpy(rseq->barcode, seq->seq.s + settings->offset, settings->blen);
+    std::memcpy(rseq->barcode, seq->seq.s + settings->offset, settings->blen);
     pass_fail &= test_hp(rseq->barcode, settings->hp_threshold);
     // Get first barcode.
     update_mseq(rseq, seq, settings->rescaler, tmp, n_len, 0);
@@ -299,7 +299,7 @@ mark_splitter_t pp_split_inline_se(marksplit_settings_t *settings)
         // Update mseq
         update_mseq(rseq, seq, settings->rescaler, tmp, n_len, 0);
         // Update barcode
-        memcpy(rseq->barcode, seq->seq.s + settings->offset, settings->blen);
+        std::memcpy(rseq->barcode, seq->seq.s + settings->offset, settings->blen);
         // Update QC Fail
         pass_fail &= test_hp(rseq->barcode, settings->hp_threshold);
         // Get bin
@@ -355,11 +355,11 @@ mark_splitter_t pp_split_inline(marksplit_settings_t *settings)
     mseq_t *rseq1(mseq_rescale_init(seq1, settings->rescaler, tmp, 0));
     mseq_t *rseq2(mseq_rescale_init(seq2, settings->rescaler, tmp, 1));
     if(switch_reads) {
-        memcpy(rseq1->barcode, seq2->seq.s + settings->offset, settings->blen1_2);
-        memcpy(rseq1->barcode + settings->blen1_2, seq1->seq.s + settings->offset, settings->blen1_2);
+        std::memcpy(rseq1->barcode, seq2->seq.s + settings->offset, settings->blen1_2);
+        std::memcpy(rseq1->barcode + settings->blen1_2, seq1->seq.s + settings->offset, settings->blen1_2);
     } else {
-        memcpy(rseq1->barcode, seq1->seq.s + settings->offset, settings->blen1_2);
-        memcpy(rseq1->barcode + settings->blen1_2, seq2->seq.s + settings->offset, settings->blen1_2);
+        std::memcpy(rseq1->barcode, seq1->seq.s + settings->offset, settings->blen1_2);
+        std::memcpy(rseq1->barcode + settings->blen1_2, seq2->seq.s + settings->offset, settings->blen1_2);
     }
     pass_fail &= test_hp(rseq1->barcode, settings->hp_threshold);
     // Get first barcode.
@@ -387,8 +387,8 @@ mark_splitter_t pp_split_inline(marksplit_settings_t *settings)
 
         if(switch_test(seq1, seq2, settings->offset)) {
             // Copy barcode over
-            memcpy(rseq1->barcode, seq2->seq.s + settings->offset, settings->blen1_2);
-            memcpy(rseq1->barcode + settings->blen1_2, seq1->seq.s + settings->offset, settings->blen1_2);
+            std::memcpy(rseq1->barcode, seq2->seq.s + settings->offset, settings->blen1_2);
+            std::memcpy(rseq1->barcode + settings->blen1_2, seq1->seq.s + settings->offset, settings->blen1_2);
             // Test for homopolymer failure
             pass_fail &= test_hp(rseq1->barcode, settings->hp_threshold);
             bin = get_binner_type(rseq1->barcode, settings->n_nucs, uint64_t);
@@ -397,8 +397,8 @@ mark_splitter_t pp_split_inline(marksplit_settings_t *settings)
             mseq2fq_stranded(splitter.tmp_out_handles_r1[bin], rseq2, pass_fail, rseq1->barcode, 'R');
             mseq2fq_stranded(splitter.tmp_out_handles_r2[bin], rseq1, pass_fail, rseq1->barcode, 'R');
         } else {
-            memcpy(rseq1->barcode, seq1->seq.s + settings->offset, settings->blen1_2);
-            memcpy(rseq1->barcode + settings->blen1_2, seq2->seq.s + settings->offset, settings->blen1_2);
+            std::memcpy(rseq1->barcode, seq1->seq.s + settings->offset, settings->blen1_2);
+            std::memcpy(rseq1->barcode + settings->blen1_2, seq2->seq.s + settings->offset, settings->blen1_2);
             pass_fail &= test_hp(rseq1->barcode, settings->hp_threshold);
             bin = bmf::get_binner_type(rseq1->barcode, settings->n_nucs, uint64_t);
             assert(bin < (uint64_t)settings->n_handles);
@@ -654,9 +654,9 @@ static mark_splitter_t splitmark_core_rescale(marksplit_settings_t *settings)
     check_rescaler(settings, NQSCORES * 2 * 4 * seq1->seq.l);
     mseq_t *rseq1(mseq_init(seq1, settings->rescaler, 0)); // rseq1 is initialized
     mseq_t *rseq2(mseq_init(seq2, settings->rescaler, 1)); // rseq2 is initialized
-    memcpy(rseq1->barcode, seq1->seq.s + settings->offset, settings->salt); // Copy in the appropriate nucleotides.
-    memcpy(rseq1->barcode + settings->salt, seq_index->seq.s, seq_index->seq.l); // Copy in the barcode
-    memcpy(rseq1->barcode + settings->salt + seq_index->seq.l, seq2->seq.s + settings->offset, settings->salt);
+    std::memcpy(rseq1->barcode, seq1->seq.s + settings->offset, settings->salt); // Copy in the appropriate nucleotides.
+    std::memcpy(rseq1->barcode + settings->salt, seq_index->seq.s, seq_index->seq.l); // Copy in the barcode
+    std::memcpy(rseq1->barcode + settings->salt + seq_index->seq.l, seq2->seq.s + settings->offset, settings->salt);
     rseq1->barcode[settings->salt * 2 + seq_index->seq.l] = '\0';
     update_mseq(rseq1, seq1, settings->rescaler, tmp, 0, 0);
     update_mseq(rseq2, seq2, settings->rescaler, tmp, 0, 1);
@@ -669,9 +669,9 @@ static mark_splitter_t splitmark_core_rescale(marksplit_settings_t *settings)
             && (l_index = kseq_read(seq_index)) >= 0) {
         if(UNLIKELY(++count % settings->notification_interval == 0))
             LOG_INFO("Number of records processed: %lu.\n", count);
-        memcpy(rseq1->barcode, seq1->seq.s + settings->offset, settings->salt); // Copy in the appropriate nucleotides.
-        memcpy(rseq1->barcode + settings->salt, seq_index->seq.s, seq_index->seq.l); // Copy in the barcode
-        memcpy(rseq1->barcode + settings->salt + seq_index->seq.l, seq2->seq.s + settings->offset, settings->salt);
+        std::memcpy(rseq1->barcode, seq1->seq.s + settings->offset, settings->salt); // Copy in the appropriate nucleotides.
+        std::memcpy(rseq1->barcode + settings->salt, seq_index->seq.s, seq_index->seq.l); // Copy in the barcode
+        std::memcpy(rseq1->barcode + settings->salt + seq_index->seq.l, seq2->seq.s + settings->offset, settings->salt);
         update_mseq(rseq1, seq1, settings->rescaler, tmp, 0, 0);
         update_mseq(rseq2, seq2, settings->rescaler, tmp, 0, 1);
         pass_fail = test_hp(rseq1->barcode, settings->hp_threshold);
@@ -710,8 +710,8 @@ static mark_splitter_t splitmark_core_rescale_se(marksplit_settings_t *settings)
     if(l < 0 || l_index < 0)
         LOG_EXIT("Could not read input fastqs. Abort mission!\n");
     mseq_t *rseq(mseq_init(seq, settings->rescaler, 0));
-    memcpy(rseq->barcode, seq->seq.s + settings->offset, settings->salt); // Copy in the appropriate nucleotides.
-    memcpy(rseq->barcode + settings->salt, seq_index->seq.s, seq_index->seq.l); // Copy in the barcode
+    std::memcpy(rseq->barcode, seq->seq.s + settings->offset, settings->salt); // Copy in the appropriate nucleotides.
+    std::memcpy(rseq->barcode + settings->salt, seq_index->seq.s, seq_index->seq.l); // Copy in the barcode
     rseq->barcode[settings->salt + seq_index->seq.l] = '\0';
     update_mseq(rseq, seq, settings->rescaler, tmp, 0, 0);
     mseq2fq(splitter.tmp_out_handles_r1[get_binner_type(rseq->barcode, settings->n_nucs, uint64_t)],
@@ -720,8 +720,8 @@ static mark_splitter_t splitmark_core_rescale_se(marksplit_settings_t *settings)
     while (LIKELY((l = kseq_read(seq)) >= 0 && (l_index = kseq_read(seq_index)) >= 0)) {
         if(UNLIKELY(++count % settings->notification_interval == 0))
             fprintf(stderr, "[%s] Number of records processed: %" PRIu64 ".\n", __func__, count);
-        memcpy(rseq->barcode, seq->seq.s + settings->offset, settings->salt); // Copy in the appropriate nucleotides.
-        memcpy(rseq->barcode + settings->salt, seq_index->seq.s, seq_index->seq.l); // Copy in the barcode
+        std::memcpy(rseq->barcode, seq->seq.s + settings->offset, settings->salt); // Copy in the appropriate nucleotides.
+        std::memcpy(rseq->barcode + settings->salt, seq_index->seq.s, seq_index->seq.l); // Copy in the barcode
         update_mseq(rseq, seq, settings->rescaler, tmp, 0, 0);
         mseq2fq(splitter.tmp_out_handles_r1[get_binner_type(rseq->barcode, settings->n_nucs, uint64_t)],
                 rseq, test_hp(rseq->barcode, settings->hp_threshold), rseq->barcode);

--- a/src/bmf_err.cpp
+++ b/src/bmf_err.cpp
@@ -1003,8 +1003,8 @@ int err_main_main(int argc, char *argv[])
         case '3': d3 = dlib::open_ofp(optarg); break;
         case 'c': dc = dlib::open_ofp(optarg); break;
         case 'n': dbc = dlib::open_ofp(optarg); break;
-        case 'r': strcpy(refcontig, optarg); break;
-        case 'b': bedpath = strdup(optarg); break;
+        case 'r': std::strcpy(refcontig, optarg); break;
+        case 'b': bedpath = optarg; break;
         case 'p': padding = atoi(optarg); break;
         case 'g': global_fp = dlib::open_ofp(optarg); break;
         case 'S': minPV = strtoul(optarg, nullptr, 0); break;
@@ -1012,7 +1012,7 @@ int err_main_main(int argc, char *argv[])
         }
     }
 
-    if(padding < 0 && bedpath && *bedpath)
+    if(padding < 0 && bedpath)
         LOG_INFO((char *)"Padding not set. Setting to default value %i.\n", DEFAULT_PADDING);
 
     if (argc != optind+2)

--- a/src/bmf_famstats.cpp
+++ b/src/bmf_famstats.cpp
@@ -1,12 +1,14 @@
 #include <getopt.h>
 #include <algorithm>
 #include "dlib/bam_util.h"
-#define __STDC_FORMAT_MACROS
+#ifndef __STDC_FORMAT_MACROS
+#  define __STDC_FORMAT_MACROS
+#endif
 #include <cinttypes>
 
 namespace bmf {
 
-const char *tags_to_check[]{"FP", "FM", "FA"};
+static const char *tags_to_check[]{"FP", "FM", "FA"};
 
 
 int famstats_frac_usage(int exit_status)
@@ -60,7 +62,7 @@ struct fm_t {
 
 static void print_hashstats(famstats_t *stats, FILE *fp)
 {
-    std::vector<fm_t> fms(stats->fm->n_occupied);
+    std::vector<fm_t> fms(kh_size(stats->fm));
     unsigned i;
     khiter_t ki;
     fprintf(fp, "#Family size\tNumber of families\n");

--- a/src/bmf_famstats.cpp
+++ b/src/bmf_famstats.cpp
@@ -289,7 +289,7 @@ int famstats_fm_main(int argc, char *argv[])
     kh_destroy(fm, s->np);
     kh_destroy(fm, s->rc);
     free(s);
-    LOG_INFO("Successfully complete bmftools famstats fm.\n");
+    LOG_INFO("Successfully completed bmftools famstats fm.\n");
     return EXIT_SUCCESS;
 }
 
@@ -338,7 +338,7 @@ int famstats_frac_main(int argc, char *argv[])
     if (ret != -1) LOG_WARNING("Truncated file? Continue anyway.\n");
     fprintf(stdout, "#Fraction of raw reads with >= minFM %u:\t%f\n",
             minFM, (double)fm_above / total_fm);
-    LOG_INFO("Successfully complete bmftools famstats frac.\n");
+    LOG_INFO("Successfully completed bmftools famstats frac.\n");
     return EXIT_SUCCESS;
 }
 

--- a/src/bmf_famstats.cpp
+++ b/src/bmf_famstats.cpp
@@ -58,17 +58,6 @@ struct fm_t {
     uint64_t fm; // Number of times observed
 };
 
-
-int get_nbins(khash_t(fm) *table)
-{
-    int ret(0);
-    for(khiter_t k = kh_begin(table); k != kh_end(table); ++k)
-        if(kh_exist(table, k))
-            ++ret;
-    return ret;
-}
-
-
 static void print_hashstats(famstats_t *stats, FILE *fp)
 {
     std::vector<fm_t> fms(stats->fm->n_occupied);

--- a/src/bmf_mark.cpp
+++ b/src/bmf_mark.cpp
@@ -134,7 +134,7 @@ int mark_main(int argc, char *argv[])
                                            &add_pe_tags, &settings);
 
     if(ret == EXIT_SUCCESS)
-        LOG_INFO("Successfully complete bmftools mark.\n");
+        LOG_INFO("Successfully completed bmftools mark.\n");
     return ret;
 }
 

--- a/src/bmf_rsq.cpp
+++ b/src/bmf_rsq.cpp
@@ -451,7 +451,7 @@ void update_bam1_unmasked(bam1_t *p, bam1_t *b)
     int pFM(bam_aux2i(pdata));
     int pTMP(0);
     if(switch_names(bam_get_qname(p), bam_get_qname(b))) {
-        memcpy(bam_get_qname(p), bam_get_qname(b), b->core.l_qname);
+        std::memcpy(bam_get_qname(p), bam_get_qname(b), b->core.l_qname);
         assert(strlen(bam_get_qname(p)) == strlen(bam_get_qname(b)));
     }
     pFM += bFM;
@@ -616,7 +616,7 @@ void update_bam1(bam1_t *p, bam1_t *b)
     int pFM(bam_aux2i(pdata));
     int pTMP(0);
     if(switch_names(bam_get_qname(p), bam_get_qname(b))) {
-        memcpy(bam_get_qname(p), bam_get_qname(b), b->core.l_qname);
+        std::memcpy(bam_get_qname(p), bam_get_qname(b), b->core.l_qname);
         assert(strlen(bam_get_qname(p)) == strlen(bam_get_qname(b)));
     }
     pFM += bFM;

--- a/src/bmf_sort.c
+++ b/src/bmf_sort.c
@@ -296,7 +296,7 @@ static inline int match_to_ks(const char *src, const hdr_match_t *match,
 
 // Append a kstring to a kstring
 static inline int ks_to_ks(kstring_t *src, kstring_t *dest) {
-    return kputsn(ks_str(src), ks_len(src), dest) != ks_len(src);
+    return (unsigned)kputsn(ks_str(src), ks_len(src), dest) != ks_len(src);
 }
 
 /*
@@ -450,7 +450,7 @@ static int trans_tbl_add_sq(merged_header_t* merged_hdr, bam_hdr_t *translate,
         }
     }
 
-    if (merged_hdr->n_targets == old_n_targets)
+    if (merged_hdr->n_targets == (unsigned)old_n_targets)
         return 0;  // Everything done if no new targets.
 
     // Otherwise, find @SQ lines in translate->text for all newly added targets.
@@ -459,7 +459,7 @@ static int trans_tbl_add_sq(merged_header_t* merged_hdr, bam_hdr_t *translate,
                             * sizeof(*new_sq_matches));
     if (new_sq_matches == NULL) goto memfail;
 
-    for (i = 0; i < merged_hdr->n_targets - old_n_targets; i++) {
+    for (i = 0; i < (int)merged_hdr->n_targets - old_n_targets; i++) {
         new_sq_matches[i].rm_so = new_sq_matches[i].rm_eo = -1;
     }
 
@@ -501,7 +501,7 @@ static int trans_tbl_add_sq(merged_header_t* merged_hdr, bam_hdr_t *translate,
     }
 
     // Copy the @SQ headers found and recreate any missing from binary header.
-    for (i = 0; i < merged_hdr->n_targets - old_n_targets; i++) {
+    for (i = 0; (unsigned)i < merged_hdr->n_targets - old_n_targets; i++) {
         if (new_sq_matches[i].rm_so >= 0) {
             if (match_to_ks(translate->text, &new_sq_matches[i], out_text))
                 goto memfail;
@@ -1686,7 +1686,7 @@ static int sort_blocks(int n_files, size_t k, bam1_p *buf, const char *prefix, c
     int n_failed = 0;
 
     if (n_threads < 1) n_threads = 1;
-    if (k < n_threads * 64) n_threads = 1; // use a single thread if we only sort a small batch of records
+    if (k < (unsigned)(n_threads << 6)) n_threads = 1; // use a single thread if we only sort a small batch of records
     pthread_attr_init(&attr);
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
     w = (worker_t*)calloc(n_threads, sizeof(worker_t));

--- a/src/bmf_target.cpp
+++ b/src/bmf_target.cpp
@@ -113,7 +113,7 @@ int target_main(int argc, char *argv[])
             padding, minmq, (double)counts.raw_target / counts.raw_count);
     fprintf(ofp, "Fraction of families of size >= 2 on target with padding of %u bases and %i minmq: %0.12f\n",
             padding, minmq, (double)counts.rfm_target / counts.rfm_count);
-    LOG_INFO("Successfully complete bmftools target!\n");
+    LOG_INFO("Successfully completed bmftools target!\n");
     fclose(ofp);
     return EXIT_SUCCESS;
 }

--- a/src/bmf_vet.cpp
+++ b/src/bmf_vet.cpp
@@ -607,14 +607,15 @@ int vet_main(int argc, char *argv[])
         if(bcf_hdr_append(aux.vcf_header, line))
             LOG_EXIT("Could not add header line '%s'. Abort!\n", line);
     bcf_hdr_printf(aux.vcf_header, "##bed_filename=\"%s\"", bed ? bed: "FullGenomeAnalysis");
-    kstring_t tmpstr{0};
-    ksprintf(&tmpstr, "##cmdline=");
-    kputs("bmftools", &tmpstr);
-    for(int i(0); i < argc; ++i) ksprintf(&tmpstr, " %s", argv[i]);
-    bcf_hdr_append(aux.vcf_header, tmpstr.s);
-    tmpstr.l = 0;
-    // Add in settings
-    free(tmpstr.s);
+    {
+        kstring_t tmpstr{0};
+        ksprintf(&tmpstr, "##cmdline=");
+        kputs("bmftools", &tmpstr);
+        for(int i(0); i < argc; ++i) ksprintf(&tmpstr, " %s", argv[i]);
+        bcf_hdr_append(aux.vcf_header, tmpstr.s);
+        // Add in settings
+        free(tmpstr.s);
+    }
     bcf_hdr_printf(aux.vcf_header, "##bmftools_version=\"%s\"", BMF_VERSION);
     std::string timestring("", 16uL);
     dlib::string_fmt_time(timestring);

--- a/util/fqt.cpp
+++ b/util/fqt.cpp
@@ -48,10 +48,10 @@ int main(int argc, char **argv)
     while(kseq_read(ks1) >= 0 && kseq_read(ks2) >= 0) {
         fqw(ks1, blen, out1);
         fqw(ks2, blen, out2);
-        memcpy(obs, ks1->seq.s, blen);
-        memcpy(obs + blen, ks2->seq.s, blen);
-        memcpy(obq, ks1->qual.s, blen);
-        memcpy(obq + blen, ks2->qual.s, blen);
+        std::memcpy(obs, ks1->seq.s, blen);
+        std::memcpy(obs + blen, ks2->seq.s, blen);
+        std::memcpy(obq, ks1->qual.s, blen);
+        std::memcpy(obq + blen, ks2->qual.s, blen);
         bcw(ks1, obs, obq, outindex);
     }
     kseq_destroy(ks1); kseq_destroy(ks2);

--- a/util/ssi2sec.cpp
+++ b/util/ssi2sec.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
     bpos[blen] = '\0';
     kseq_t *bks(use_read1 ? ks1: ks2);
     while(kseq_read(ks1) >= 0 && kseq_read(ks2) >= 0) {
-        memcpy(bpos, bks->seq.s, blen);
+        std::memcpy(bpos, bks->seq.s, blen);
         fprintf(outindex, "@%s barcode\n%s\n+\n", ks1->name.s, bpos);
         fwrite(bks->qual.s, 20, 1, outindex);
         fputc('\n', outindex);


### PR DESCRIPTION
Fixes a segmentation fault when reads don't have comments fields. [See [this issue](https://github.com/ARUP-NGS/BMFtools/issues/98).]

Also included are small style changes. (More std::, small fix in random string generation in collapse.)